### PR TITLE
Allow integer doc IDs

### DIFF
--- a/src/granite_common/base/types.py
+++ b/src/granite_common/base/types.py
@@ -167,7 +167,7 @@ class Document(pydantic.BaseModel, NoDefaultsMixin):
     documents."""
 
     text: str
-    doc_id: str | None = None
+    doc_id: str | int | None = None
 
 
 class ChatTemplateKwargs(pydantic.BaseModel, NoDefaultsMixin):

--- a/tests/granite_common/granite3/test_granite33.py
+++ b/tests/granite_common/granite3/test_granite33.py
@@ -126,7 +126,7 @@ old."}
     [
         {"doc_id": "abc", 
          "text": "It's a small world, but I wouldn't want to have to paint it."},
-        {"doc_id": "213", 
+        {"doc_id": 213,
          "text": "Whenever I think of the past, it brings back so many memories."}
     ]
 }


### PR DESCRIPTION
This PR backports a change from granite-io that allows integer document IDs for Granite 3.3 chat completions.