### PR TITLE
Add environment to pypi workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -51,6 +51,7 @@ jobs:
     # - a PR is merged into main branch
     publish-test-pypi:
         name: Publish packages to test.pypi.org
+        environment: release
         if: |
             github.repository_owner == 'ibm-granite' && (
                 github.event.action == 'published' ||
@@ -84,6 +85,7 @@ jobs:
     # - a new GitHub release is published
     publish-pypi:
         name: Publish release to pypi.org
+        environment: release
         if: |
             github.repository_owner == 'ibm-granite' && github.event.action == 'published'
         permissions:


### PR DESCRIPTION
This PR adds an `environment` tag to the publish workflow to use the Github environment that has permission to push packages.