### PR TITLE
Shorten class names

### DIFF
--- a/src/granite_common/__init__.py
+++ b/src/granite_common/__init__.py
@@ -14,14 +14,14 @@ from .base.types import (
     UserMessage,
 )
 from .granite3.granite32 import (
-    Granite3Point2ChatCompletion,
-    Granite3Point2InputProcessor,
-    Granite3Point2OutputProcessor,
+    Granite32ChatCompletion,
+    Granite32InputProcessor,
+    Granite32OutputProcessor,
 )
 from .granite3.granite33 import (
-    Granite3Point3ChatCompletion,
-    Granite3Point3InputProcessor,
-    Granite3Point3OutputProcessor,
+    Granite33ChatCompletion,
+    Granite33InputProcessor,
+    Granite33OutputProcessor,
 )
 
 # The contents of __all__ must be strings
@@ -31,11 +31,11 @@ __all__ = (
         AssistantMessage,
         ChatCompletion,
         UserMessage,
-        Granite3Point2InputProcessor,
-        Granite3Point2OutputProcessor,
-        Granite3Point2ChatCompletion,
-        Granite3Point3ChatCompletion,
-        Granite3Point3InputProcessor,
-        Granite3Point3OutputProcessor,
+        Granite32InputProcessor,
+        Granite32OutputProcessor,
+        Granite32ChatCompletion,
+        Granite33ChatCompletion,
+        Granite33InputProcessor,
+        Granite33OutputProcessor,
     )
 )

--- a/src/granite_common/granite3/granite32/__init__.py
+++ b/src/granite_common/granite3/granite32/__init__.py
@@ -5,12 +5,12 @@ Input and output processing for the Granite 3.2 family of models.
 """
 
 # Local
-from .input import Granite3Point2InputProcessor
-from .output import Granite3Point2OutputProcessor
-from .types import Granite3Point2ChatCompletion
+from .input import Granite32InputProcessor
+from .output import Granite32OutputProcessor
+from .types import Granite32ChatCompletion
 
 __all__ = (
-    "Granite3Point2ChatCompletion",
-    "Granite3Point2InputProcessor",
-    "Granite3Point2OutputProcessor",
+    "Granite32ChatCompletion",
+    "Granite32InputProcessor",
+    "Granite32OutputProcessor",
 )

--- a/src/granite_common/granite3/granite32/input.py
+++ b/src/granite_common/granite3/granite32/input.py
@@ -27,10 +27,10 @@ from .constants import (
     TOOLS_AND_DOCS_SYSTEM_MESSAGE_PART,
     TOOLS_AND_NO_DOCS_SYSTEM_MESSAGE_PART,
 )
-from .types import Granite3Point2ChatCompletion
+from .types import Granite32ChatCompletion
 
 
-class Granite3Point2InputProcessor(Granite3InputProcessor):
+class Granite32InputProcessor(Granite3InputProcessor):
     """
     Input processor for version 3.2 of the main Granite models, all sizes.
 
@@ -130,7 +130,7 @@ class Granite3Point2InputProcessor(Granite3InputProcessor):
     """
 
     def _build_default_system_message(
-        self, chat_completion: Granite3Point2ChatCompletion
+        self, chat_completion: Granite32ChatCompletion
     ) -> str:
         """
         :chat_completion: Chat completion request that does not include a custom
@@ -162,7 +162,7 @@ class Granite3Point2InputProcessor(Granite3InputProcessor):
         # The default system message starts with a header that includes the date and
         # knowledge cutoff.
         system_message = "<|start_of_role|>system<|end_of_role|>"
-        system_message += Granite3Point2InputProcessor._make_system_message_start()
+        system_message += Granite32InputProcessor._make_system_message_start()
 
         # Add a middle part that varies depending on tools, documents, and citations.
         if have_documents and have_tools:
@@ -207,7 +207,7 @@ class Granite3Point2InputProcessor(Granite3InputProcessor):
     ) -> str:
         # Downcast to a Model-specific request type with possible additional fields.
         # This operation also performs additional validation.
-        chat_completion = Granite3Point2ChatCompletion.model_validate(
+        chat_completion = Granite32ChatCompletion.model_validate(
             chat_completion.model_dump()
         )
 

--- a/src/granite_common/granite3/granite32/output.py
+++ b/src/granite_common/granite3/granite32/output.py
@@ -55,7 +55,7 @@ from .constants import (
     COT_START_ALTERNATIVES,
     HALLUCINATION_START,
 )
-from .types import Granite3Point2ChatCompletion
+from .types import Granite32ChatCompletion
 
 # Setup logger
 logger = logging.getLogger(__name__)
@@ -594,7 +594,7 @@ def _parse_model_output(
     return result
 
 
-class Granite3Point2OutputProcessor(OutputProcessor):
+class Granite32OutputProcessor(OutputProcessor):
     """
     Output processor for version 3.2 of the main Granite models, all sizes.
     """
@@ -604,7 +604,7 @@ class Granite3Point2OutputProcessor(OutputProcessor):
     ) -> AssistantMessage:
         # Downcast to a Granite-specific request type with possible additional fields.
         # This operation also performs additional validation.
-        chat_completion = Granite3Point2ChatCompletion.model_validate(
+        chat_completion = Granite32ChatCompletion.model_validate(
             chat_completion.model_dump()
         )
 

--- a/src/granite_common/granite3/granite32/types.py
+++ b/src/granite_common/granite3/granite32/types.py
@@ -12,7 +12,7 @@ from granite_common.base.types import Document
 from granite_common.granite3.types import Granite3ChatCompletion
 
 
-class Granite3Point2ChatCompletion(Granite3ChatCompletion):
+class Granite32ChatCompletion(Granite3ChatCompletion):
     """
     Class that represents the inputs to a Granite 3.2 model generation call.
     """

--- a/src/granite_common/granite3/granite33/__init__.py
+++ b/src/granite_common/granite3/granite33/__init__.py
@@ -5,12 +5,12 @@ Input and output processing for the Granite 3.3 family of models.
 """
 
 # Local
-from .input import Granite3Point3InputProcessor
-from .output import Granite3Point3OutputProcessor
-from .types import Granite3Point3ChatCompletion
+from .input import Granite33InputProcessor
+from .output import Granite33OutputProcessor
+from .types import Granite33ChatCompletion
 
 __all__ = (
-    "Granite3Point3ChatCompletion",
-    "Granite3Point3InputProcessor",
-    "Granite3Point3OutputProcessor",
+    "Granite33ChatCompletion",
+    "Granite33InputProcessor",
+    "Granite33OutputProcessor",
 )

--- a/src/granite_common/granite3/granite33/input.py
+++ b/src/granite_common/granite3/granite33/input.py
@@ -27,10 +27,10 @@ from .constants import (
     TOOLS_AND_DOCS_SYSTEM_MESSAGE_PART,
     TOOLS_AND_NO_DOCS_SYSTEM_MESSAGE_PART,
 )
-from .types import Granite3Point3ChatCompletion
+from .types import Granite33ChatCompletion
 
 
-class Granite3Point3InputProcessor(Granite3InputProcessor):
+class Granite33InputProcessor(Granite3InputProcessor):
     """
     Input processor for version 3.3 of the main Granite models, all sizes.
     This input processor is based on the Jinja template from tokenizer_config.json.
@@ -41,7 +41,7 @@ class Granite3Point3InputProcessor(Granite3InputProcessor):
     """  # noqa: E501
 
     def _build_default_system_message(
-        self, chat_completion: Granite3Point3ChatCompletion
+        self, chat_completion: Granite33ChatCompletion
     ) -> str:
         """
         :param inputs: Chat completion request that does not include a custom
@@ -74,7 +74,7 @@ class Granite3Point3InputProcessor(Granite3InputProcessor):
         # The default system message starts with a header that includes the date and
         # knowledge cutoff.
         system_message = "<|start_of_role|>system<|end_of_role|>"
-        system_message += Granite3Point3InputProcessor._make_system_message_start()
+        system_message += Granite33InputProcessor._make_system_message_start()
 
         # Add a middle part that varies depending on tools, documents, and citations.
         if have_documents and have_tools:
@@ -120,7 +120,7 @@ class Granite3Point3InputProcessor(Granite3InputProcessor):
     ) -> str:
         # Downcast to a Granite-specific request type with possible additional fields.
         # This operation also performs additional validation.
-        chat_completion = Granite3Point3ChatCompletion.model_validate(
+        chat_completion = Granite33ChatCompletion.model_validate(
             chat_completion.model_dump()
         )
 

--- a/src/granite_common/granite3/granite33/output.py
+++ b/src/granite_common/granite3/granite33/output.py
@@ -49,7 +49,7 @@ from .constants import (
     RESPONSE_END,
     RESPONSE_START,
 )
-from .types import Granite3Point3ChatCompletion
+from .types import Granite33ChatCompletion
 
 # Setup logger
 logger = logging.getLogger(__name__)
@@ -418,7 +418,7 @@ def _update_docs_text_with_input_docs(
 
 
 def _parse_model_output(
-    model_output: str, chat_completion: Granite3Point3ChatCompletion
+    model_output: str, chat_completion: Granite33ChatCompletion
 ) -> list[str | dict]:
     """
     Parse the constituents of the output (response) of a model into
@@ -526,7 +526,7 @@ def _parse_model_output(
     return result
 
 
-class Granite3Point3OutputProcessor(OutputProcessor):
+class Granite33OutputProcessor(OutputProcessor):
     """
     Output processor for version 3.3 of the main Granite models, all sizes.
     """
@@ -536,9 +536,7 @@ class Granite3Point3OutputProcessor(OutputProcessor):
     ) -> AssistantMessage:
         # Downcast to a Granite-specific request type with possible additional fields.
         # This operation also performs additional validation.
-        inputs = Granite3Point3ChatCompletion.model_validate(
-            chat_completion.model_dump()
-        )
+        inputs = Granite33ChatCompletion.model_validate(chat_completion.model_dump())
 
         # Save a copy because code below mutates this variable
         original_output = model_output

--- a/src/granite_common/granite3/granite33/types.py
+++ b/src/granite_common/granite3/granite33/types.py
@@ -12,7 +12,7 @@ from granite_common.base.types import Document
 from granite_common.granite3.types import Granite3ChatCompletion
 
 
-class Granite3Point3ChatCompletion(Granite3ChatCompletion):
+class Granite33ChatCompletion(Granite3ChatCompletion):
     """
     Class that represents the inputs to a Granite 3.3 model generation call.
     """

--- a/tests/granite_common/granite3/test_granite32.py
+++ b/tests/granite_common/granite3/test_granite32.py
@@ -17,9 +17,9 @@ import transformers
 from granite_common import (
     AssistantMessage,
     ChatCompletion,
-    Granite3Point2ChatCompletion,
-    Granite3Point2InputProcessor,
-    Granite3Point2OutputProcessor,
+    Granite32ChatCompletion,
+    Granite32InputProcessor,
+    Granite32OutputProcessor,
     UserMessage,
 )
 from granite_common.granite3.granite32 import constants
@@ -264,9 +264,7 @@ def test_read_inputs(input_json_str):
     assert input_obj == input_obj_2
 
     # Parse additional Model-specific fields
-    granite_input_obj = Granite3Point2ChatCompletion.model_validate(
-        input_obj.model_dump()
-    )
+    granite_input_obj = Granite32ChatCompletion.model_validate(input_obj.model_dump())
 
     # Verify that we can convert back to JSON without crashing
     granite_input_obj.model_dump_json()
@@ -293,8 +291,8 @@ def test_same_input_string(
     )
 
     # Then compare against the input processor
-    inputs = Granite3Point2ChatCompletion.model_validate_json(input_json_str)
-    io_proc_str = Granite3Point2InputProcessor().transform(inputs)
+    inputs = Granite32ChatCompletion.model_validate_json(input_json_str)
+    io_proc_str = Granite32InputProcessor().transform(inputs)
 
     print(f"{io_proc_str=}")
     print(f"{transformers_str=}")
@@ -326,7 +324,7 @@ def test_basic_inputs_to_string():
     <|start_of_role|>user<|end_of_role|>I'd like to show off how chat templating works!\
 <|end_of_text|>
     """
-    chatRequest = Granite3Point2InputProcessor().transform(
+    chatRequest = Granite32InputProcessor().transform(
         chat_completion=ChatCompletion(
             messages=[
                 UserMessage(content="Hello, how are you?"),
@@ -363,8 +361,8 @@ def test_run_model(
     """
     Run inference end-to-end with each of the test inputs in this file.
     """
-    chat_completion = Granite3Point2ChatCompletion.model_validate_json(input_json_str)
-    prompt = Granite3Point2InputProcessor().transform(chat_completion)
+    chat_completion = Granite32ChatCompletion.model_validate_json(input_json_str)
+    prompt = Granite32InputProcessor().transform(chat_completion)
     model_input = tokenizer(prompt, return_tensors="pt").to(model.device)
     generation_config = transformers.GenerationConfig(
         max_length=1024, num_beams=1, do_sample=False
@@ -378,9 +376,7 @@ def test_run_model(
         skip_special_tokens=True,
     )
 
-    next_message = Granite3Point2OutputProcessor().transform(
-        model_output, chat_completion
-    )
+    next_message = Granite32OutputProcessor().transform(model_output, chat_completion)
 
     print(f"{next_message=}")
 
@@ -410,7 +406,7 @@ def test_run_model(
 )
 def test_cot_parsing(chat_completion, model_output, exp_thought, exp_resp):
     """Test the parsing logic for CoT reasoning output"""
-    result = Granite3Point2OutputProcessor().transform(model_output, chat_completion)
+    result = Granite32OutputProcessor().transform(model_output, chat_completion)
     assert result.reasoning_content == exp_thought
     assert result.content == exp_resp
     assert result.raw_content is None or result.raw_content == model_output
@@ -464,7 +460,7 @@ def test_citation_hallucination_parsing(
     exp_resp,
 ):
     """Test the parsing logic for Rag and hallucinations output"""
-    result = Granite3Point2OutputProcessor().transform(model_output, chat_completion)
+    result = Granite32OutputProcessor().transform(model_output, chat_completion)
     assert result.content == exp_resp
     assert result.citations == exp_citation
     assert result.documents == exp_document

--- a/tests/granite_common/granite3/test_granite33.py
+++ b/tests/granite_common/granite3/test_granite33.py
@@ -16,9 +16,9 @@ import transformers
 # First Party
 from granite_common import (
     AssistantMessage,
-    Granite3Point3ChatCompletion,
-    Granite3Point3InputProcessor,
-    Granite3Point3OutputProcessor,
+    Granite33ChatCompletion,
+    Granite33InputProcessor,
+    Granite33OutputProcessor,
     UserMessage,
 )
 from granite_common.granite3.granite33 import constants
@@ -135,8 +135,8 @@ old."}
 
 
 msg = UserMessage(content="Hello")
-no_thinking_input = Granite3Point3ChatCompletion(messages=[msg])
-thinking_input = Granite3Point3ChatCompletion(messages=[msg], thinking=True)
+no_thinking_input = Granite33ChatCompletion(messages=[msg])
+thinking_input = Granite33ChatCompletion(messages=[msg], thinking=True)
 
 thought = "Think think"
 response = "respond respond"
@@ -180,7 +180,7 @@ expected_citation = Citation(
     response_end=14,
 )
 expected_document = Document(doc_id="1", text="Dog info")
-doc_input = Granite3Point3ChatCompletion(
+doc_input = Granite33ChatCompletion(
     messages=[msg], documents=[{"doc_id": "1", "text": "Dog info"}]
 )
 expected_hallucination = Hallucination(
@@ -262,15 +262,13 @@ def test_read_inputs(input_json_str):
     Granite 3.3 JSON
     """
     input_json = json.loads(input_json_str)
-    input_obj = Granite3Point3ChatCompletion.model_validate(input_json)
-    input_obj_2 = Granite3Point3ChatCompletion.model_validate_json(input_json_str)
+    input_obj = Granite33ChatCompletion.model_validate(input_json)
+    input_obj_2 = Granite33ChatCompletion.model_validate_json(input_json_str)
 
     assert input_obj == input_obj_2
 
     # Parse additional Granite-specific fields
-    granite_input_obj = Granite3Point3ChatCompletion.model_validate(
-        input_obj.model_dump()
-    )
+    granite_input_obj = Granite33ChatCompletion.model_validate(input_obj.model_dump())
 
     # Verify that we can convert back to JSON without crashing
     granite_input_obj.model_dump_json()
@@ -297,8 +295,8 @@ def test_same_input_string(
     )
 
     # Then compare against the input processor
-    inputs = Granite3Point3ChatCompletion.model_validate_json(input_json_str)
-    io_proc_str = Granite3Point3InputProcessor().transform(inputs)
+    inputs = Granite33ChatCompletion.model_validate_json(input_json_str)
+    io_proc_str = Granite33InputProcessor().transform(inputs)
 
     print(f"{io_proc_str=}")
     print(f"{transformers_str=}")
@@ -330,8 +328,8 @@ def test_basic_inputs_to_string():
     <|start_of_role|>user<|end_of_role|>I'd like to show off how chat templating works!\
 <|end_of_text|>
     """
-    chatRequest = Granite3Point3InputProcessor().transform(
-        chat_completion=Granite3Point3ChatCompletion(
+    chatRequest = Granite33InputProcessor().transform(
+        chat_completion=Granite33ChatCompletion(
             messages=[
                 UserMessage(content="Hello, how are you?"),
                 AssistantMessage(content="I'm doing great. How can I help you today?"),
@@ -369,8 +367,8 @@ def test_run_model(
     """
     Run inference end-to-end with each of the test inputs in this file.
     """
-    chat_completion = Granite3Point3ChatCompletion.model_validate_json(input_json_str)
-    prompt = Granite3Point3InputProcessor().transform(chat_completion)
+    chat_completion = Granite33ChatCompletion.model_validate_json(input_json_str)
+    prompt = Granite33InputProcessor().transform(chat_completion)
     model_input = tokenizer(prompt, return_tensors="pt").to(model.device)
     generation_config = transformers.GenerationConfig(
         max_length=1024, num_beams=1, do_sample=False
@@ -384,9 +382,7 @@ def test_run_model(
         skip_special_tokens=True,
     )
 
-    next_message = Granite3Point3OutputProcessor().transform(
-        model_output, chat_completion
-    )
+    next_message = Granite33OutputProcessor().transform(model_output, chat_completion)
 
     print(f"{next_message=}")
 
@@ -416,7 +412,7 @@ def test_run_model(
 )
 def test_cot_parsing(chat_completion, model_output, exp_thought, exp_resp):
     """Test the parsing logic for CoT reasoning output"""
-    result = Granite3Point3OutputProcessor().transform(model_output, chat_completion)
+    result = Granite33OutputProcessor().transform(model_output, chat_completion)
     assert result.reasoning_content == exp_thought
     assert result.content == exp_resp
     assert result.raw_content is None or result.raw_content == model_output
@@ -477,7 +473,7 @@ def test_citation_hallucination_parsing(
     controls.hallucinations = True
     chat_completion.controls = controls
 
-    result = Granite3Point3OutputProcessor().transform(model_output, chat_completion)
+    result = Granite33OutputProcessor().transform(model_output, chat_completion)
     assert result.content == exp_resp
     assert result.citations == exp_citation
     assert result.documents == exp_document


### PR DESCRIPTION
This PR shortens the names of the Granite input and output processing classes by replacing `3Point2` and `3Point3` with `32` and `33` respectively.