### PR TITLE
Align chat completion format with vLLM

### DIFF
--- a/src/granite_common/__init__.py
+++ b/src/granite_common/__init__.py
@@ -11,6 +11,7 @@ parsing for IBM Granite models
 from .base.types import (
     AssistantMessage,
     ChatCompletion,
+    GraniteChatCompletion,
     UserMessage,
 )
 from .granite3.granite32 import (
@@ -37,5 +38,6 @@ __all__ = (
         Granite33ChatCompletion,
         Granite33InputProcessor,
         Granite33OutputProcessor,
+        GraniteChatCompletion,
     )
 )

--- a/src/granite_common/base/types.py
+++ b/src/granite_common/base/types.py
@@ -240,7 +240,10 @@ class ChatCompletion(pydantic.BaseModel, NoDefaultsMixin):
     )
 
     model_config = pydantic.ConfigDict(
-        extra="forbid",
+        # If an input to this library is an actual vLLM chat completion request, then
+        # the request will likely contain additional fields. Ignore these fields for
+        # the purposes of `granite-common`.
+        extra="ignore",
     )
 
 

--- a/src/granite_common/base/types.py
+++ b/src/granite_common/base/types.py
@@ -5,9 +5,10 @@ Common shared types
 """
 
 # Standard
-from typing import Literal, TypeAlias
+from typing import Literal, Self, TypeAlias
 
 # Third Party
+from pydantic import Field
 from typing_extensions import Any
 import pydantic
 
@@ -70,6 +71,11 @@ class NoDefaultsMixin:
                 # Sometimes Pydantic adds fields to self.model_fields_set without adding
                 # them to the output of self.model_dump()
                 result[f] = getattr(self, f)
+        for f in self._reserialize_these_fields():
+            # Sometimes Pydantic's serializer fails to serialize sub-objects correctly
+            field_value = getattr(self, f)
+            if field_value is not None:
+                result[f] = field_value.model_dump()
         return result
 
     def _keep_these_fields(self) -> tuple[str]:
@@ -79,6 +85,17 @@ class NoDefaultsMixin:
 
         This is necessary for round-tripping to JSON when there are fields that
         determine which dataclass to use for deserialization.
+        """
+        return ()
+
+    def _reserialize_these_fields(self) -> tuple[str]:
+        """
+        Dataclasses that include this mixin can override this method to trigger
+        replacing the serialized values of fields with the results of calling
+        :func:`model_dump()` on this fields.
+
+        This is necessary because Pydantic's serializer sometimes produces incorrect
+        outputs for child objects for reasons unknown when called on the parent object.
         """
         return ()
 
@@ -167,31 +184,51 @@ class Document(pydantic.BaseModel, NoDefaultsMixin):
     documents."""
 
     text: str
+    title: str | None = None
     doc_id: str | int | None = None
 
 
-class ChatTemplateKwargs(pydantic.BaseModel, NoDefaultsMixin):
+class ChatTemplateKwargs(pydantic.BaseModel):
     """
     Values that can appear in the ``chat_template_kwargs`` portion of a valid chat
     completion request for a Granite model.
     """
 
-    documents: list[Document] | None = None
+    model_config = pydantic.ConfigDict(
+        # Pass through arbitrary additional keyword arguments for handling by
+        # model-specific I/O processors.
+        arbitrary_types_allowed=True,
+        extra="allow",
+    )
 
 
 class ChatCompletion(pydantic.BaseModel, NoDefaultsMixin):
     """
-    Lowest-common-denominator inputs to a chat completion request for an IBM Granite
-    model.
-
-    The schema of this object mirrors that of a chat completion request in vLLM's
-    OpenAI-compatible inference API.
+    Subset of the schema of a chat completion request in vLLM's OpenAI-compatible
+    inference API that is exercised by Granite models.
     """
 
     messages: list[ChatMessage]
     model: str | None = None
     tools: list[ToolDefinition] | None = None
-
+    documents: list[Document] | None = Field(
+        default=None,
+        description=(
+            "A list of dicts representing documents that will be accessible to "
+            "the model if it is performing RAG (retrieval-augmented generation)."
+            " If the template does not support RAG, this argument will have no "
+            "effect. We recommend that each document should be a dict containing "
+            '"title" and "text" keys.'
+        ),
+    )
+    add_generation_prompt: bool = Field(
+        default=True,
+        description=(
+            "If true, the generation prompt will be added to the chat template. "
+            "This is a parameter used by chat template in tokenizer config of the "
+            "model."
+        ),
+    )
     chat_template_kwargs: ChatTemplateKwargs | None = pydantic.Field(
         default=None,
         description=(
@@ -203,15 +240,43 @@ class ChatCompletion(pydantic.BaseModel, NoDefaultsMixin):
     )
 
     model_config = pydantic.ConfigDict(
-        # Pass through arbitrary additional keyword arguments for handling by
-        # model-specific I/O processors.
-        arbitrary_types_allowed=True,
-        extra="allow",
+        extra="forbid",
     )
 
-    def __getattr__(self, name: str) -> any:
-        """Allow attribute access for unknown attributes"""
-        try:
-            return super().__getattr__(name)
-        except AttributeError:
-            return None
+
+class GraniteChatCompletion(ChatCompletion):
+    """
+    Lowest-common-denominator inputs to a chat completion request for an IBM Granite
+    model.
+    """
+
+    @pydantic.model_validator(mode="after")
+    def _validate_documents_at_top_level(self) -> Self:
+        """Documents for a Granite model chat completion request should be passed in the
+        ``documents`` argument at the top level of the request.
+
+        Detect cases where the documents are hanging off of ``chat_template_kwargs``
+        and sanitize appropriately.
+        """
+        if self.chat_template_kwargs and hasattr(
+            self.chat_template_kwargs, "documents"
+        ):
+            if self.documents is not None:
+                raise ValueError(
+                    "Conflicting values of documents found in top-level "
+                    "'documents' parameter and inside "
+                    "'chat_template_kwargs'"
+                )
+            if not isinstance(self.chat_template_kwargs.documents, list):
+                raise ValueError(
+                    "'documents' parameter inside 'chat_template_kwargs' is not a list"
+                )
+
+            # Round-trip through dict so that documents field disappears from JSON
+            # representation.
+            args = self.chat_template_kwargs.model_dump()
+            self.documents = [Document.model_validate(d) for d in args["documents"]]
+            del args["documents"]
+            self.chat_template_kwargs = ChatTemplateKwargs.model_validate(args)
+
+        return self

--- a/src/granite_common/granite3/__init__.py
+++ b/src/granite_common/granite3/__init__.py
@@ -5,6 +5,6 @@ Input and output processing for the Granite 3 family of models.
 """
 
 # Local
-from .types import ControlsRecord
+from .types import Granite3Controls
 
-__all__ = ("ControlsRecord",)
+__all__ = ("Granite3Controls",)

--- a/src/granite_common/granite3/granite32/input.py
+++ b/src/granite_common/granite3/granite32/input.py
@@ -141,18 +141,20 @@ class Granite32InputProcessor(Granite3InputProcessor):
         # bool([]) == bool(None) == False
         have_documents = bool(chat_completion.documents)
         have_tools = bool(chat_completion.tools)
+        have_thinking = chat_completion.thinking()
+        controls = chat_completion.controls()
 
         # Carefully hew to the policy that the original Jinja template's behavior
         # defines.
         # First, disallow the cases that the authors of the Jinja template did not
         # provide any code to handle.
-        if chat_completion.thinking and have_documents:
+        if have_thinking and have_documents:
             raise ValueError(
                 f"'thinking' flag is set, but documents were provided. "
                 f"{MODEL_NAME} only supports the 'thinking' flag when "
                 f"documents are not provided."
             )
-        if chat_completion.thinking and have_tools:
+        if have_thinking and have_tools:
             raise ValueError(
                 f"'thinking' flag is set, but tools were provided. "
                 f"{MODEL_NAME} only supports the 'thinking' flag when "
@@ -171,13 +173,13 @@ class Granite32InputProcessor(Granite3InputProcessor):
             system_message += NO_TOOLS_AND_DOCS_SYSTEM_MESSAGE_PART
         elif have_tools:  # and not have_documents
             system_message += TOOLS_AND_NO_DOCS_SYSTEM_MESSAGE_PART
-        elif chat_completion.thinking:  # if not have_documents and not have_tools
+        elif have_thinking:  # if not have_documents and not have_tools
             system_message += NO_TOOLS_AND_NO_DOCS_AND_THINKING_SYSTEM_MESSAGE_PART
         else:  # if not inputs.thinking and not have_documents and not have_tools
             system_message += NO_TOOLS_NO_DOCS_NO_THINKING_SYSTEM_MESSAGE_PART
 
         # Next comes an optional section of instructions for citations.
-        if chat_completion.controls and chat_completion.controls.citations:
+        if controls.citations:
             if not have_documents:
                 # TODO: The template skips the citations instruction in this case.
                 # Is this behavior an error? Should we raise an error if the caller
@@ -187,7 +189,7 @@ class Granite32InputProcessor(Granite3InputProcessor):
                 system_message += DOCS_AND_CITATIONS_SYSTEM_MESSAGE_PART
 
         # Then comes an optional section of instructions for hallucinations.
-        if chat_completion.controls and chat_completion.controls.hallucinations:
+        if controls.hallucinations:
             if not have_documents:
                 raise ValueError(
                     f"'hallucinations' flag is set, but the model input does not "
@@ -210,12 +212,14 @@ class Granite32InputProcessor(Granite3InputProcessor):
         chat_completion = Granite32ChatCompletion.model_validate(
             chat_completion.model_dump()
         )
+        controls = chat_completion.controls()
+        have_thinking = chat_completion.thinking()
 
         # Check for a caller-provided system message
         system_message_json, loop_messages = self._split_messages(chat_completion)
 
         if system_message_json is not None:
-            if chat_completion.thinking:
+            if have_thinking:
                 raise ValueError(
                     f"'thinking' flag is set, but the model input includes a custom "
                     f"system message. {MODEL_NAME} only supports the "
@@ -227,13 +231,13 @@ class Granite32InputProcessor(Granite3InputProcessor):
                     f"{MODEL_NAME} only supports the documents list when "
                     f"the default system message is used."
                 )
-            if chat_completion.controls and chat_completion.controls.citations:
+            if controls.citations:
                 raise ValueError(
                     f"'citations' flag is set, but the model input includes a custom "
                     f"system message. {MODEL_NAME} only supports the "
                     f"'citations' flag when the default system message is used."
                 )
-            if chat_completion.controls and chat_completion.controls.hallucinations:
+            if controls.hallucinations:
                 raise ValueError(
                     f"'hallucinations' flag is set, but the model input includes a "
                     f"custom system message. {MODEL_NAME} only supports "

--- a/src/granite_common/granite3/granite32/types.py
+++ b/src/granite_common/granite3/granite32/types.py
@@ -17,8 +17,6 @@ class Granite32ChatCompletion(Granite3ChatCompletion):
     Class that represents the inputs to a Granite 3.2 model generation call.
     """
 
-    thinking: bool = False
-
     @pydantic.field_validator("documents")
     @classmethod
     def _validate_documents(cls, documents: list[Document] | None) -> list | None:

--- a/src/granite_common/granite3/granite33/constants.py
+++ b/src/granite_common/granite3/granite33/constants.py
@@ -75,7 +75,7 @@ list all the citations with their corresponding documents in an ordered list."""
 # DOCS_AND_CITATIONS_SYSTEM_MESSAGE_PART in the system prompt
 # if the "hallucinations" flag is `True` and there are documents.
 # Note that a list of zero documents counts as "having documents".
-DOCS_AND_HALLUCINATIONS_SYSTEM_MESSAGE_PART = """ \
+DOCS_AND_HALLUCINATIONS_SYSTEM_MESSAGE_PART = """\
 
 Finally, after the response is written, include a numbered list of sentences from the \
 response with a corresponding risk value that are hallucinated and not based in the \

--- a/src/granite_common/granite3/granite33/input.py
+++ b/src/granite_common/granite3/granite33/input.py
@@ -53,18 +53,20 @@ class Granite33InputProcessor(Granite3InputProcessor):
         # use.
         have_documents = bool(chat_completion.documents)
         have_tools = bool(chat_completion.tools)
+        have_thinking = chat_completion.thinking()
+        controls = chat_completion.controls()
 
         # Carefully hew to the policy that the original Jinja template's behavior
         # defines.
         # First, disallow the cases that the authors of the Jinja template did not
         # provide any code to handle.
-        if chat_completion.thinking and have_documents:
+        if have_thinking and have_documents:
             raise ValueError(
                 f"'thinking' flag is set, but documents were provided. "
                 f"{MODEL_NAME} only supports the 'thinking' flag when "
                 f"documents are not provided."
             )
-        if chat_completion.thinking and have_tools:
+        if have_thinking and have_tools:
             raise ValueError(
                 f"'thinking' flag is set, but tools were provided. "
                 f"{MODEL_NAME} only supports the 'thinking' flag when "
@@ -83,14 +85,14 @@ class Granite33InputProcessor(Granite3InputProcessor):
             system_message += NO_TOOLS_AND_DOCS_SYSTEM_MESSAGE_PART
         elif have_tools:  # and not have_documents
             system_message += TOOLS_AND_NO_DOCS_SYSTEM_MESSAGE_PART
-        elif chat_completion.thinking:  # if not have_documents and not have_tools
+        elif have_thinking:  # if not have_documents and not have_tools
             system_message += NO_TOOLS_AND_NO_DOCS_AND_THINKING_SYSTEM_MESSAGE_PART
         else:
-            # if not chat_completion.thinking and not have_documents and not have_tools
+            # if not have_thinking and not have_documents and not have_tools
             system_message += NO_TOOLS_NO_DOCS_NO_THINKING_SYSTEM_MESSAGE_PART
 
         # Next comes an optional section of instructions for citations.
-        if chat_completion.controls and chat_completion.controls.citations:
+        if controls.citations:
             if not have_documents:
                 # TODO: The template skips the citations instruction in this case.
                 # Is this behavior an error? Should we raise an error if the caller
@@ -100,7 +102,7 @@ class Granite33InputProcessor(Granite3InputProcessor):
                 system_message += DOCS_AND_CITATIONS_SYSTEM_MESSAGE_PART
 
         # Then comes an optional section of instructions for hallucinations.
-        if chat_completion.controls and chat_completion.controls.hallucinations:
+        if controls.hallucinations:
             if not have_documents:
                 raise ValueError(
                     f"'hallucinations' flag is set, but the model input does not "
@@ -123,12 +125,14 @@ class Granite33InputProcessor(Granite3InputProcessor):
         chat_completion = Granite33ChatCompletion.model_validate(
             chat_completion.model_dump()
         )
+        have_thinking = chat_completion.thinking()
+        controls = chat_completion.controls()
 
         # Check for a caller-provided system message
         system_message_json, loop_messages = self._split_messages(chat_completion)
 
         if system_message_json is not None:
-            if chat_completion.thinking:
+            if have_thinking:
                 raise ValueError(
                     f"'thinking' flag is set, but the model input includes a custom "
                     f"system message. {MODEL_NAME} only supports the "
@@ -140,13 +144,13 @@ class Granite33InputProcessor(Granite3InputProcessor):
                     f"{MODEL_NAME} only supports the documents list when "
                     f"the default system message is used."
                 )
-            if chat_completion.controls and chat_completion.controls.citations:
+            if controls.citations:
                 raise ValueError(
                     f"'citations' flag is set, but the model input includes a custom "
                     f"system message. {MODEL_NAME} only supports the "
                     f"'citations' flag when the default system message is used."
                 )
-            if chat_completion.controls and chat_completion.controls.hallucinations:
+            if controls.hallucinations:
                 raise ValueError(
                     f"'hallucinations' flag is set, but the model input includes a "
                     f"custom system message. {MODEL_NAME} only supports "

--- a/src/granite_common/granite3/granite33/output.py
+++ b/src/granite_common/granite3/granite33/output.py
@@ -333,7 +333,11 @@ def _split_model_output_into_parts(model_output: str) -> tuple[str, str, str]:
     hallucinations_text = ""
 
     if HALLUCINATIONS_START in model_output and CITATIONS_START not in model_output:
-        response_text, hallucinations_text = model_output.split(HALLUCINATIONS_START)
+        # rsplit because sometimes the model produces multiple copies of the
+        # hallucinations output.
+        response_text, hallucinations_text = model_output.rsplit(
+            HALLUCINATIONS_START, 1
+        )
     elif CITATIONS_START in model_output and HALLUCINATIONS_START not in model_output:
         response_text, citations_text = model_output.split(CITATIONS_START)
     elif CITATIONS_START in model_output and HALLUCINATIONS_START in model_output:
@@ -543,7 +547,7 @@ class Granite33OutputProcessor(OutputProcessor):
 
         # Parse out CoT reasoning
         cot = None
-        if inputs.thinking:
+        if inputs.thinking():
             cot_start_span = None
             cot_end_span = None
             for cot_start_str in COT_START_ALTERNATIVES:

--- a/src/granite_common/granite3/input.py
+++ b/src/granite_common/granite3/input.py
@@ -97,18 +97,23 @@ You are Granite, developed by IBM."""
         :returns: A fake JSON record for "controls", or nothing of no output control
         flags were set.
         """
-        if not chat_completion.controls:
+        if (
+            not chat_completion.chat_template_kwargs
+            or not chat_completion.chat_template_kwargs.controls
+        ):
             return None
+        controls = chat_completion.chat_template_kwargs.controls
+
         result = {}
-        if chat_completion.controls.citations:
+        if controls.citations:
             # The following is a guess; we have no example data for this case.
             result["citations"] = True
-        if chat_completion.controls.hallucinations:
+        if controls.hallucinations:
             # The following is a guess; we have no example data for this case.
             result["hallucinations"] = True
-        if chat_completion.controls.length is not None:
+        if controls.length is not None:
             result["length"] = chat_completion.controls.length
-        if chat_completion.controls.originality is not None:
+        if controls.originality is not None:
             result["originality"] = chat_completion.controls.originality
 
         if len(result) == 0:

--- a/tests/granite_common/granite3/test_granite32.py
+++ b/tests/granite_common/granite3/test_granite32.py
@@ -25,10 +25,10 @@ from granite_common import (
 from granite_common.granite3.granite32 import constants
 from granite_common.granite3.types import (
     Citation,
-    ControlsRecord,
     Document,
     Granite3AssistantMessage,
     Granite3ChatCompletion,
+    Granite3Controls,
     Hallucination,
 )
 
@@ -52,20 +52,20 @@ INPUT_JSON_STRS = {
     [
         {"role": "user", "content": "What is 1 + 1? Answer with just a number please."}
     ],
-    "thinking": true
+    "chat_template_kwargs": {"thinking": true}
 }
 """,
     "hallucinations": """
 {
     "messages":
     [
-        {"role": "user", "content": "Who invented the flub flibber?"}
+        {"role": "user", "content": "Where is the fleeby floop?"}
     ],
     "documents":
     [
-        {"text": "Joe Smith invented the wheel."}
+        {"text": "The fleeby floop is in Maine."}
     ],
-    "hallucinations": true
+    "chat_template_kwargs": {"controls": {"hallucinations": true}}
 }
 """,
     "custom_system_prompt": """
@@ -135,7 +135,7 @@ old."}
 
 msg = UserMessage(content="Hello")
 no_thinking_input = ChatCompletion(messages=[msg])
-thinking_input = ChatCompletion(messages=[msg], thinking=True)
+thinking_input = ChatCompletion(messages=[msg], chat_template_kwargs={"thinking": True})
 
 thought = "Think think"
 response = "respond respond"
@@ -247,9 +247,9 @@ def _model() -> transformers.AutoModelForCausalLM:
 def test_controls_field_validators(length, originality, error):
     if error:
         with pytest.raises(pydantic.ValidationError, match=error):
-            ControlsRecord(length=length, originality=originality)
+            Granite3Controls(length=length, originality=originality)
     else:
-        ControlsRecord(length=length, originality=originality)
+        Granite3Controls(length=length, originality=originality)
 
 
 def test_read_inputs(input_json_str):
@@ -283,6 +283,13 @@ def test_same_input_string(
     input_json = json.loads(input_json_str)
     input_kwargs = input_json.copy()
     del input_kwargs["messages"]
+
+    # Pull up elements of chat_template_kwargs, emulating what vLLM does internally.
+    if "chat_template_kwargs" in input_kwargs:
+        for k, v in input_kwargs["chat_template_kwargs"].items():
+            input_kwargs[k] = v
+        del input_kwargs["chat_template_kwargs"]
+
     transformers_str = tokenizer.apply_chat_template(
         input_json["messages"],
         **input_kwargs,
@@ -375,6 +382,8 @@ def test_run_model(
         model_output_tensor[0, model_input["input_ids"].shape[1] :],
         skip_special_tokens=True,
     )
+
+    print(f"{model_output=}")
 
     next_message = Granite32OutputProcessor().transform(model_output, chat_completion)
 

--- a/tests/granite_common/granite3/test_granite33.py
+++ b/tests/granite_common/granite3/test_granite33.py
@@ -24,9 +24,10 @@ from granite_common import (
 from granite_common.granite3.granite33 import constants
 from granite_common.granite3.types import (
     Citation,
-    ControlsRecord,
     Document,
     Granite3AssistantMessage,
+    Granite3Controls,
+    Granite3Kwargs,
     Hallucination,
 )
 
@@ -50,7 +51,7 @@ INPUT_JSON_STRS = {
     [
         {"role": "user", "content": "What is 1 + 1? Answer with just a number please."}
     ],
-    "thinking": true
+    "chat_template_kwargs": {"thinking": true}
 }
 """,
     "hallucinations": """
@@ -63,7 +64,7 @@ INPUT_JSON_STRS = {
     [
         {"doc_id": "42", "text": "Joe Smith invented the wheel."}
     ],
-    "hallucinations": true
+    "chat_template_kwargs": {"controls": {"hallucinations": true}}
 }
 """,
     "custom_system_prompt": """
@@ -136,7 +137,9 @@ old."}
 
 msg = UserMessage(content="Hello")
 no_thinking_input = Granite33ChatCompletion(messages=[msg])
-thinking_input = Granite33ChatCompletion(messages=[msg], thinking=True)
+thinking_input = Granite33ChatCompletion(
+    messages=[msg], chat_template_kwargs={"thinking": True}
+)
 
 thought = "Think think"
 response = "respond respond"
@@ -251,9 +254,9 @@ def _model() -> transformers.AutoModelForCausalLM:
 def test_controls_field_validators(length, originality, error):
     if error:
         with pytest.raises(pydantic.ValidationError, match=error):
-            ControlsRecord(length=length, originality=originality)
+            Granite3Controls(length=length, originality=originality)
     else:
-        ControlsRecord(length=length, originality=originality)
+        Granite3Controls(length=length, originality=originality)
 
 
 def test_read_inputs(input_json_str):
@@ -287,6 +290,15 @@ def test_same_input_string(
     input_json = json.loads(input_json_str)
     input_kwargs = input_json.copy()
     del input_kwargs["messages"]
+
+    # Pull up elements of chat_template_kwargs, emulating what vLLM does internally.
+    if "chat_template_kwargs" in input_kwargs:
+        for k, v in input_kwargs["chat_template_kwargs"].items():
+            input_kwargs[k] = v
+        del input_kwargs["chat_template_kwargs"]
+
+    print(f"{input_kwargs=}")
+
     transformers_str = tokenizer.apply_chat_template(
         input_json["messages"],
         **input_kwargs,
@@ -468,10 +480,10 @@ def test_citation_hallucination_parsing(
     """Test the parsing logic for Rag and hallucinations output"""
 
     # Controls must be explicitly enabled, see issue #173.
-    controls = ControlsRecord()
+    controls = Granite3Controls()
     controls.citations = True
     controls.hallucinations = True
-    chat_completion.controls = controls
+    chat_completion.chat_template_kwargs = Granite3Kwargs(controls=controls)
 
     result = Granite33OutputProcessor().transform(model_output, chat_completion)
     assert result.content == exp_resp


### PR DESCRIPTION
This PR adjusts the structure of the `ChatCompletion` dataclass so that it is a subset of vLLM's chat completion JSON format. A fair amount of massaging of code that depends on this dataclass was necessary to put the change into effect.

Test cases with embedded JSON data have been modified to use the new format.

The change exposed a bug in hallucination parsing, which is also fixed in this PR.

Closes #14 