### PR TITLE
Align chat completion more closely with OpenAI APIs

### DIFF
--- a/src/granite_common/__init__.py
+++ b/src/granite_common/__init__.py
@@ -13,6 +13,7 @@ from .base.types import (
     ChatCompletion,
     GraniteChatCompletion,
     UserMessage,
+    VLLMExtraBody,
 )
 from .granite3.granite32 import (
     Granite32ChatCompletion,
@@ -41,5 +42,6 @@ __all__ = (
         Granite33OutputProcessor,
         GraniteChatCompletion,
         RagAgentLibRewriter,
+        VLLMExtraBody,
     )
 )

--- a/src/granite_common/granite3/granite32/input.py
+++ b/src/granite_common/granite3/granite32/input.py
@@ -141,7 +141,7 @@ class Granite32InputProcessor(Granite3InputProcessor):
             as a string suitable to feed to the model's tokenizer.
         """
         # bool([]) == bool(None) == False
-        have_documents = bool(chat_completion.documents)
+        have_documents = bool(chat_completion._documents())
         have_tools = bool(chat_completion.tools)
         have_thinking = chat_completion.thinking()
         controls = chat_completion.controls()
@@ -254,7 +254,7 @@ class Granite32InputProcessor(Granite3InputProcessor):
                     f"system message. {MODEL_NAME} only supports the "
                     f"'thinking' flag when the default system message is used."
                 )
-            if chat_completion.documents:
+            if chat_completion._documents():
                 raise ValueError(
                     f"The model input includes documents and a custom system message. "
                     f"{MODEL_NAME} only supports the documents list when "
@@ -292,13 +292,13 @@ class Granite32InputProcessor(Granite3InputProcessor):
                 + "<|end_of_text|>\n"
             )
 
-        if not bool(chat_completion.documents):
+        if not bool(chat_completion._documents()):
             documents_part = ""
         else:
             documents_body = "\n\n".join(
                 [
-                    f"Document {i}\n{chat_completion.documents[i].text}"
-                    for i in range(len(chat_completion.documents))
+                    f"Document {i}\n{chat_completion._documents()[i].text}"
+                    for i in range(len(chat_completion._documents()))
                 ]
             )
             documents_part = (

--- a/src/granite_common/granite3/granite32/output.py
+++ b/src/granite_common/granite3/granite32/output.py
@@ -663,7 +663,9 @@ class Granite32OutputProcessor(OutputProcessor):
 
         # Parse out citations, documents and hallucinations
         try:
-            parsed_output = _parse_model_output(model_output, chat_completion.documents)
+            parsed_output = _parse_model_output(
+                model_output, chat_completion._documents()
+            )
         except Exception as err:
             raise ValueError(
                 "Failed to parse citations, documents and hallucinations "

--- a/src/granite_common/granite3/granite32/types.py
+++ b/src/granite_common/granite3/granite32/types.py
@@ -8,7 +8,7 @@ Dataclasses that are specific to the Granite 3.2 family of models.
 import pydantic
 
 # First Party
-from granite_common.base.types import Document
+from granite_common.base.types import Document, VLLMExtraBody
 from granite_common.granite3.types import Granite3ChatCompletion
 
 
@@ -17,14 +17,14 @@ class Granite32ChatCompletion(Granite3ChatCompletion):
     Class that represents the inputs to a Granite 3.2 model generation call.
     """
 
-    @pydantic.field_validator("documents")
+    @pydantic.field_validator("extra_body")
     @classmethod
-    def _validate_documents(cls, documents: list[Document] | None) -> list | None:
+    def _validate_documents(cls, extra_body: VLLMExtraBody) -> VLLMExtraBody:
         """
         Granite 3.2 documents should not have document IDs.
         """
-        if documents is not None:
-            for i, d in enumerate(documents):
+        if extra_body.documents:
+            for i, d in enumerate(extra_body.documents):
                 if not isinstance(d, Document):
                     raise TypeError(
                         f"Expected Document at position {i} but found "
@@ -36,4 +36,4 @@ class Granite32ChatCompletion(Granite3ChatCompletion):
                         f"field. This field is not allowed for Granite "
                         f"3.2."
                     )
-        return documents
+        return extra_body

--- a/src/granite_common/granite3/granite33/input.py
+++ b/src/granite_common/granite3/granite33/input.py
@@ -53,7 +53,7 @@ class Granite33InputProcessor(Granite3InputProcessor):
         """
         # Compute the predicates that determine exactly what default system message to
         # use.
-        have_documents = bool(chat_completion.documents)
+        have_documents = bool(chat_completion._documents())
         have_tools = bool(chat_completion.tools)
         have_thinking = chat_completion.thinking()
         controls = chat_completion.controls()
@@ -173,7 +173,7 @@ class Granite33InputProcessor(Granite3InputProcessor):
                     f"system message. {MODEL_NAME} only supports the "
                     f"'thinking' flag when the default system message is used."
                 )
-            if chat_completion.documents:
+            if chat_completion._documents():
                 raise ValueError(
                     f"The model input includes documents and a custom system message. "
                     f"{MODEL_NAME} only supports the documents list when "
@@ -211,14 +211,14 @@ class Granite33InputProcessor(Granite3InputProcessor):
                 + "<|end_of_text|>\n"
             )
 
-        if not chat_completion.documents:
+        if not chat_completion._documents():
             documents_part = ""
         else:
             documents_part = "".join(
                 [
                     f'<|start_of_role|>document {{"document_id": "{d.doc_id}"}}'
                     f"<|end_of_role|>\n{d.text}<|end_of_text|>\n"
-                    for d in chat_completion.documents
+                    for d in chat_completion._documents()
                 ]
             )
 

--- a/src/granite_common/granite3/granite33/output.py
+++ b/src/granite_common/granite3/granite33/output.py
@@ -458,7 +458,7 @@ def _parse_model_output(
         logger.debug(f"Response text without controls:\n{result}\n")
         return result
 
-    docs_from_input = chat_completion.documents
+    docs_from_input = chat_completion._documents()
 
     # Split model output into its parts: response, citation, and hallucination section
     response_text, citations_text, hallucinations_text = _split_model_output_into_parts(

--- a/src/granite_common/granite3/granite33/types.py
+++ b/src/granite_common/granite3/granite33/types.py
@@ -8,7 +8,7 @@ Dataclasses that are specific to the Granite 3.3 family of models.
 import pydantic
 
 # First Party
-from granite_common.base.types import Document
+from granite_common.base.types import Document, VLLMExtraBody
 from granite_common.granite3.types import Granite3ChatCompletion
 
 
@@ -17,14 +17,14 @@ class Granite33ChatCompletion(Granite3ChatCompletion):
     Class that represents the inputs to a Granite 3.3 model generation call.
     """
 
-    @pydantic.field_validator("documents")
+    @pydantic.field_validator("extra_body")
     @classmethod
-    def _validate_documents(cls, documents: list[Document] | None) -> list | None:
+    def _validate_documents(cls, extra_body: VLLMExtraBody) -> VLLMExtraBody:
         """
         Granite 3.3 documents must have document IDs.
         """
-        if documents is not None:
-            for i, d in enumerate(documents):
+        if extra_body.documents:
+            for i, d in enumerate(extra_body.documents):
                 if not isinstance(d, Document):
                     raise TypeError(
                         f"Expected Document at position {i} but found "
@@ -36,4 +36,4 @@ class Granite33ChatCompletion(Granite3ChatCompletion):
                         f"field. This field is required for Granite "
                         f"3.3."
                     )
-        return documents
+        return extra_body

--- a/src/granite_common/granite3/input.py
+++ b/src/granite_common/granite3/input.py
@@ -99,11 +99,11 @@ You are Granite, developed by IBM."""
         flags were set.
         """
         if (
-            not chat_completion.chat_template_kwargs
-            or not chat_completion.chat_template_kwargs.controls
+            not chat_completion._chat_template_kwargs()
+            or not chat_completion._chat_template_kwargs().controls
         ):
             return None
-        controls = chat_completion.chat_template_kwargs.controls
+        controls = chat_completion._chat_template_kwargs().controls
 
         result = {}
         if controls.citations:
@@ -175,8 +175,8 @@ You are Granite, developed by IBM."""
                         if len(kk) > 0:
                             new_params[kk] = vv
                     tool.parameters = new_params
-        if ("documents" in parts or "all" in parts) and chat_completion.documents:
-            for document in chat_completion.documents:
+        if ("documents" in parts or "all" in parts) and chat_completion._documents():
+            for document in chat_completion._documents():
                 if document.doc_id and isinstance(document.doc_id, str):
                     document.doc_id = remove_special_tokens(document.doc_id)
                 document.text = remove_special_tokens(document.text)

--- a/tests/granite_common/base/test_types.py
+++ b/tests/granite_common/base/test_types.py
@@ -53,19 +53,37 @@ def test_chat_completion():
 
 
 def test_granite_chat_completion():
-    with pytest.raises(ValueError, match="Conflicting values of documents"):
+    with pytest.raises(ValueError, match="'documents' parameter at top level"):
         types.GraniteChatCompletion.model_validate(
             {"messages": [], "documents": [], "chat_template_kwargs": {"documents": []}}
         )
+    with pytest.raises(ValueError, match="Conflicting values of documents"):
+        types.GraniteChatCompletion.model_validate(
+            {
+                "messages": [],
+                "extra_body": {
+                    "documents": [],
+                    "chat_template_kwargs": {"documents": []},
+                },
+            }
+        )
     with pytest.raises(ValueError, match="not a list"):
         types.GraniteChatCompletion.model_validate(
-            {"messages": [], "chat_template_kwargs": {"documents": "foo"}}
+            {
+                "messages": [],
+                "extra_body": {"chat_template_kwargs": {"documents": "foo"}},
+            }
         )
 
     # Documents in kwargs should be moved to top-level arg
     docs_in_kwargs = types.GraniteChatCompletion.model_validate(
-        {"messages": [], "chat_template_kwargs": {"documents": [{"text": "hello"}]}}
+        {
+            "messages": [],
+            "extra_body": {"chat_template_kwargs": {"documents": [{"text": "hello"}]}},
+        }
     )
     assert docs_in_kwargs.documents is not None
-    assert not hasattr(docs_in_kwargs.chat_template_kwargs, "documents")
-    assert "documents" not in docs_in_kwargs.chat_template_kwargs.model_dump()
+    assert not hasattr(docs_in_kwargs.extra_body.chat_template_kwargs, "documents")
+    assert (
+        "documents" not in docs_in_kwargs.extra_body.chat_template_kwargs.model_dump()
+    )

--- a/tests/granite_common/rag_agent_lib/testdata/input_json/answerable.json
+++ b/tests/granite_common/rag_agent_lib/testdata/input_json/answerable.json
@@ -9,10 +9,12 @@
       "role": "user"
     }
   ],
-  "documents": [
-    {
-        "doc_id": 1,
-        "text": "The square root of 4 is 2."
-    }
-  ]
+  "extra_body": {
+    "documents": [
+      {
+          "doc_id": 1,
+          "text": "The square root of 4 is 2."
+      }
+    ]
+  }
 }

--- a/tests/granite_common/rag_agent_lib/testdata/input_json/hallucination.json
+++ b/tests/granite_common/rag_agent_lib/testdata/input_json/hallucination.json
@@ -13,10 +13,12 @@
       "content": "Purple bumble fish are yellow. Green bumble fish are also yellow."
     }
   ],
-  "documents": [
-    {
-        "doc_id": 1,
-        "text": "The only type of fish that is yellow is the purple bumble fish."
-    }
-  ]
+  "extra_body": {
+    "documents": [
+      {
+          "doc_id": 1,
+          "text": "The only type of fish that is yellow is the purple bumble fish."
+      }
+    ]
+  }
 }

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answerability_answerable.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answerability_answerable.json
@@ -10,18 +10,20 @@
     }
   ],
   "model": "answerability",
-  "documents": [
-    {
-      "text": "The square root of 4 is 2.",
-      "doc_id": 1
+  "extra_body": {
+    "documents": [
+      {
+        "text": "The square root of 4 is 2.",
+        "doc_id": 1
+      }
+    ],
+    "guided_json": {
+      "type": "string",
+      "enum": [
+        "answerable",
+        "unanswerable"
+      ]
     }
-  ],
-  "guided_json": {
-    "type": "string",
-    "enum": [
-      "answerable",
-      "unanswerable"
-    ]
   },
   "max_completion_tokens": 6,
   "logprobs": true

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answerability_extra_params.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answerability_extra_params.json
@@ -6,12 +6,14 @@
     }
   ],
   "model": "answerability",
-  "guided_json": {
-    "type": "string",
-    "enum": [
-      "answerable",
-      "unanswerable"
-    ]
+  "extra_body": {
+    "guided_json": {
+      "type": "string",
+      "enum": [
+        "answerable",
+        "unanswerable"
+      ]
+    }
   },
   "frequency_penalty": 0.1,
   "n": 5,

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answerability_simple.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answerability_simple.json
@@ -6,12 +6,14 @@
     }
   ],
   "model": "answerability",
-  "guided_json": {
-    "type": "string",
-    "enum": [
-      "answerable",
-      "unanswerable"
-    ]
+  "extra_body": {
+    "guided_json": {
+      "type": "string",
+      "enum": [
+        "answerable",
+        "unanswerable"
+      ]
+    }
   },
   "max_completion_tokens": 6,
   "logprobs": true

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/hallucination.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/hallucination.json
@@ -17,44 +17,46 @@
       "role": "user"
     }
   ],
-  "documents": [
-    {
-      "text": "The only type of fish that is yellow is the purple bumble fish.",
-      "doc_id": 1
-    }
-  ],
-  "guided_json": {
-    "$defs": {
-      "HallucinationOutputEntry": {
-        "properties": {
-          "sentence_num": {
-            "minimum": 0,
-            "title": "Sentence Num",
-            "type": "integer"
-          },
-          "reasoning": {
-            "title": "Reasoning",
-            "type": "string"
-          },
-          "is_faithful": {
-            "title": "Is Faithful",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "sentence_num",
-          "reasoning",
-          "is_faithful"
-        ],
-        "title": "HallucinationOutputEntry",
-        "type": "object"
+  "extra_body": {
+    "documents": [
+      {
+        "text": "The only type of fish that is yellow is the purple bumble fish.",
+        "doc_id": 1
       }
-    },
-    "items": {
-      "$ref": "#/$defs/HallucinationOutputEntry"
-    },
-    "title": "HallucinationOutput",
-    "type": "array"
+    ],
+    "guided_json": {
+      "$defs": {
+        "HallucinationOutputEntry": {
+          "properties": {
+            "sentence_num": {
+              "minimum": 0,
+              "title": "Sentence Num",
+              "type": "integer"
+            },
+            "reasoning": {
+              "title": "Reasoning",
+              "type": "string"
+            },
+            "is_faithful": {
+              "title": "Is Faithful",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "sentence_num",
+            "reasoning",
+            "is_faithful"
+          ],
+          "title": "HallucinationOutputEntry",
+          "type": "object"
+        }
+      },
+      "items": {
+        "$ref": "#/$defs/HallucinationOutputEntry"
+      },
+      "title": "HallucinationOutput",
+      "type": "array"
+    }
   },
   "max_completion_tokens": 1024,
   "logprobs": true

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/instruction.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/instruction.json
@@ -14,12 +14,14 @@
     }
   ],
   "model": "dummy-model-1b",
-  "guided_json": {
-    "type": "string",
-    "enum": [
-      "fish",
-      "not fish"
-    ]
+  "extra_body": {
+    "guided_json": {
+      "type": "string",
+      "enum": [
+        "fish",
+        "not fish"
+      ]
+    }
   },
   "max_completion_tokens": 42,
   "temperature": 0.75,

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/rewrite.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/rewrite.json
@@ -25,18 +25,20 @@
       "role": "user"
     }
   ],
-  "guided_json": {
-    "properties": {
-      "rewritten_question": {
-        "title": "Rewritten Question",
-        "type": "string"
-      }
-    },
-    "required": [
-      "rewritten_question"
-    ],
-    "title": "QueryRewriteOutput",
-    "type": "object"
+  "extra_body": {
+    "guided_json": {
+      "properties": {
+        "rewritten_question": {
+          "title": "Rewritten Question",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rewritten_question"
+      ],
+      "title": "QueryRewriteOutput",
+      "type": "object"
+    }
   },
   "temperature": 0.0,
   "n": 1024,


### PR DESCRIPTION
The current version of the `ChatCompletion` class can't be directly passed to the OpenAI Python API's `chat.completions.create()` method, due to the fields `documents` and `guided_json` being at the top level of the request instead of inside the `extra_body` parameter. This PR moves those fields under `extra_body` so that the OpenAI library works directly on the output of `ChatCompletion.model_dump()`