### PR TITLE
Improve OpenAI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pytest-html",
     "pytest-retry~=1.7",
     "pytest-xdist",
+    "pytest-recording",  # Used for blocking network access
     "ruff==0.12.10",
     "tox",
     "anywidget",

--- a/src/granite_common/__init__.py
+++ b/src/granite_common/__init__.py
@@ -25,7 +25,7 @@ from .granite3.granite33 import (
     Granite33InputProcessor,
     Granite33OutputProcessor,
 )
-from .rag_agent_lib import RagAgentLibRewriter
+from .rag_agent_lib import RagAgentLibResultProcessor, RagAgentLibRewriter
 
 # The contents of __all__ must be strings
 __all__ = (
@@ -42,6 +42,7 @@ __all__ = (
         Granite33OutputProcessor,
         GraniteChatCompletion,
         RagAgentLibRewriter,
+        RagAgentLibResultProcessor,
         VLLMExtraBody,
     )
 )

--- a/src/granite_common/base/types.py
+++ b/src/granite_common/base/types.py
@@ -185,7 +185,9 @@ class Document(pydantic.BaseModel, NoDefaultsMixin):
 
     text: str
     title: str | None = None
-    doc_id: str | int | None = None
+
+    # vLLM requires document IDs to be strings
+    doc_id: str | None = None
 
 
 class ChatTemplateKwargs(pydantic.BaseModel):

--- a/tests/granite_common/granite3/test_granite33.py
+++ b/tests/granite_common/granite3/test_granite33.py
@@ -134,7 +134,7 @@ old."}
         [
             {"doc_id": "abc",
             "text": "It's a small world, but I wouldn't want to have to paint it."},
-            {"doc_id": 213,
+            {"doc_id": "213",
             "text": "Whenever I think of the past, it brings back so many memories."}
         ]
     }

--- a/tests/granite_common/granite3/test_granite33.py
+++ b/tests/granite_common/granite3/test_granite33.py
@@ -8,6 +8,7 @@ Tests of code under ``granite_common.granite3.granite33``
 import json
 
 # Third Party
+import openai
 import pydantic
 import pytest
 import torch
@@ -370,6 +371,27 @@ def _model() -> transformers.AutoModelForCausalLM:
     except Exception as e:  # pylint: disable=broad-exception-caught
         pytest.skip(f"No model for {model_path}: {e}")
     return ret
+
+
+@pytest.mark.block_network
+def test_openai_compat(input_json_str: str):
+    """
+    Verify that the dataclasses for Granite 3.3 chat completions can be directly passed
+    to the OpenAI Python API without raising parsing errors.
+    """
+    input_obj = Granite33ChatCompletion.model_validate_json(input_json_str)
+
+    # Create a fake connection to the API so we can use its request validation code
+    # Note that network access is blocked for this test case.
+    openai_base_url = "http://localhost:98765/not/a/valid/url"
+    openai_api_key = "not_a_valid_api_key"
+    client = openai.OpenAI(base_url=openai_base_url, api_key=openai_api_key)
+
+    # The client should get all the way through validation and fail to connect
+    with pytest.raises(openai.APIConnectionError):
+        client.chat.completions.create(
+            model="dummy_model_name", **(input_obj.model_dump())
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/granite_common/rag_agent_lib/test_rag_agent_lib.py
+++ b/tests/granite_common/rag_agent_lib/test_rag_agent_lib.py
@@ -182,7 +182,7 @@ def test_openai_compat(yaml_json_combo: str):
     to the OpenAI Python API without raising parsing errors.
     """
 
-    short_name, yaml_file, json_file, _ = yaml_json_combo
+    _, yaml_file, json_file, _ = yaml_json_combo
 
     # Temporary: Use a YAML file from local disk
     rewriter = RagAgentLibRewriter(config_file=yaml_file)

--- a/tests/granite_common/rag_agent_lib/testdata/input_json/answerable.json
+++ b/tests/granite_common/rag_agent_lib/testdata/input_json/answerable.json
@@ -12,7 +12,7 @@
   "extra_body": {
     "documents": [
       {
-          "doc_id": 1,
+          "doc_id": "1",
           "text": "The square root of 4 is 2."
       }
     ]

--- a/tests/granite_common/rag_agent_lib/testdata/input_json/hallucination.json
+++ b/tests/granite_common/rag_agent_lib/testdata/input_json/hallucination.json
@@ -16,7 +16,7 @@
   "extra_body": {
     "documents": [
       {
-          "doc_id": 1,
+          "doc_id": "1",
           "text": "The only type of fish that is yellow is the purple bumble fish."
       }
     ]

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answerability_answerable.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answerability_answerable.json
@@ -14,7 +14,7 @@
     "documents": [
       {
         "text": "The square root of 4 is 2.",
-        "doc_id": 1
+        "doc_id": "1"
       }
     ],
     "guided_json": {

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/hallucination.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/hallucination.json
@@ -21,7 +21,7 @@
     "documents": [
       {
         "text": "The only type of fish that is yellow is the purple bumble fish.",
-        "doc_id": 1
+        "doc_id": "1"
       }
     ],
     "guided_json": {

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_output/model_input/answerability_answerable.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_output/model_input/answerability_answerable.json
@@ -13,7 +13,7 @@
   "documents": [
     {
       "text": "The square root of 4 is 2.",
-      "doc_id": 1
+      "doc_id": "1"
     }
   ],
   "guided_json": {

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_output/model_input/answerability_unanswerable.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_output/model_input/answerability_unanswerable.json
@@ -11,11 +11,11 @@
   ],
   "documents": [
     {
-        "doc_id": 1,
+        "doc_id": "1",
         "text": "My dog has fleas."
     },
     {
-        "doc_id": 2,
+        "doc_id": "2",
         "text": "My cat does not have fleas."
     }
   ],


### PR DESCRIPTION
This PR adds tests to ensure that the dataclasses for chat completions can pass the validation code in the OpenAI Python API's `chat.completions.create()` function.

During manual testing with vLLM, I found that vLLM chokes on integer field values under the `documents` element, so I've also changed `doc_id` to be string only.