### PR TITLE
Add sentence splitting and stubs for sentence output processing

### DIFF
--- a/src/granite_common/rag_agent_lib/output.py
+++ b/src/granite_common/rag_agent_lib/output.py
@@ -216,7 +216,43 @@ class TokenToFloat(TransformationRule):
         return sum(w * v for w, v in zip(weights, values, strict=True))
 
 
-NAME_TO_RULE = {"likelihood": TokenToFloat}
+class DecodeSentences(TransformationRule):
+    """
+    Transformation rule that decodes references to sentences by number into
+    """
+
+    def __init__(
+        self,
+        input_path_expr: list[str | int | None],
+        output_name: str | None,
+        /,
+        source: str,
+    ):
+        """
+        :param source: Name of the field to replace with decoded sentences.
+        """
+        super().__init__(input_path_expr, output_name)
+        self.source = source
+
+    def _transform(
+        self,
+        value: Any,
+        logprobs: ChatCompletionLogProbs | None,
+        begin_to_token: dict | None,
+    ) -> Any:
+        raise NotImplementedError("This code is currently a stub.")
+
+        # TODO: Modify the base class so that apply() can see the REWRITTEN chat
+        # completion request
+        # TODO: Modify the base class so that there is an optional setup hook in
+        # apply() that creates a lookup table which is then passed to _transform()
+        # TODO: In the setup hook, find the locations of sentence boundary markers
+        # in the REWRITTEN chat completion request
+        # TODO: In _transform(), replace references to sentences by number with the
+        # appropriate (begin, end, sentence) tuples.
+
+
+NAME_TO_RULE = {"likelihood": TokenToFloat, "decode_sentences": DecodeSentences}
 
 
 class RagAgentLibResultProcessor(ChatCompletionResultProcessor):

--- a/tests/granite_common/rag_agent_lib/test_rag_agent_lib.py
+++ b/tests/granite_common/rag_agent_lib/test_rag_agent_lib.py
@@ -99,6 +99,18 @@ _YAML_JSON_COMBOS = {
         None,  # TODO: Add model once we have a checkpoint
         _INPUT_ARGS_DIR / "context_relevance.json",
     ),
+    "answer_relevance_classifier": (
+        _INPUT_YAML_DIR / "answer_relevance_classifier.yaml",
+        _INPUT_JSON_DIR / "answer_relevance_classifier.json",
+        None,  # TODO: Add model once we have a checkpoint
+        None,
+    ),
+    "answer_relevance_rewriter": (
+        _INPUT_YAML_DIR / "answer_relevance_rewriter.yaml",
+        _INPUT_JSON_DIR / "answer_relevance_rewriter.json",
+        None,  # TODO: Add model once we have a checkpoint
+        _INPUT_ARGS_DIR / "answer_relevance_rewriter.json",
+    ),
 }
 
 _YAML_JSON_COMBOS_WITH_MODEL = {

--- a/tests/granite_common/rag_agent_lib/testdata/input_args/answer_relevance_rewriter.json
+++ b/tests/granite_common/rag_agent_lib/testdata/input_args/answer_relevance_rewriter.json
@@ -1,0 +1,5 @@
+{
+    "answer_relevance_category": "Misinterpreted question",
+    "answer_relevance_analysis": "The response does not address the question about who attended the meeting. It provides a general statement about many people attending the meeting but does not specify who those people were. This is not relevant to the question asked. The response is also missing the closing tag.",
+    "correction_method": "providing answer only to the correct interpretation of the inquiry, or attempting clarification if the inquiry is ambiguous or otherwise confusing, or indicating that the desired answer is not available"
+}

--- a/tests/granite_common/rag_agent_lib/testdata/input_json/answer_relevance_classifier.json
+++ b/tests/granite_common/rag_agent_lib/testdata/input_json/answer_relevance_classifier.json
@@ -1,0 +1,13 @@
+{
+  "messages": [
+    {"role": "user", "content": "Who attended the meeting?"},
+    {"role": "assistant", "content": "Many people attended the meeting."}
+  ],
+  "extra_body": {
+    "documents": [
+        {"doc_id": "1", "text": "Meeting attendees: Alice, Bob, Carol."},
+        {"doc_id": "2", "text": "Meeting time: 9:00 am to 11:00 am."}
+    ]
+  },
+  "temperature": 0.0 
+}

--- a/tests/granite_common/rag_agent_lib/testdata/input_json/answer_relevance_rewriter.json
+++ b/tests/granite_common/rag_agent_lib/testdata/input_json/answer_relevance_rewriter.json
@@ -1,0 +1,13 @@
+{
+  "messages": [
+    {"role": "user", "content": "Who attended the meeting?"},
+    {"role": "assistant", "content": "Many people attended the meeting."}
+  ],
+  "extra_body": {
+    "documents": [
+        {"doc_id": "1", "text": "Meeting attendees: Alice, Bob, Carol."},
+        {"doc_id": "2", "text": "Meeting time: 9:00 am to 11:00 am."}
+    ]
+  },
+  "temperature": 0.0 
+}

--- a/tests/granite_common/rag_agent_lib/testdata/input_yaml/answer_relevance_classifier.yaml
+++ b/tests/granite_common/rag_agent_lib/testdata/input_yaml/answer_relevance_classifier.yaml
@@ -1,0 +1,43 @@
+# Model name string, or null to use whatever is provided in the chat completion request
+model: ~
+# JSON schema of the model's output
+response_format:  |
+  {
+    "properties": {
+      "answer_relevance_analysis": {
+        "title": "Answer Relevance Analysis",
+        "type": "string"
+      },
+      "answer_relevance_category": {
+        "title": "Answer Relevance Category",
+        "type": "string",
+        "enum": [
+          "Pertinent", 
+          "Pertinent with relevant extra",
+          "Excessive unnecessary information",
+          "Unduly restrictive",
+          "Too vague or generic",
+          "Contextual misalignment",
+          "Misinterpreted inquiry",
+          "No attempt"
+        ]
+      },
+      "answer_relevance_judgment": {
+        "title": "Answer Relevance Judgment",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "answer_relevance_analysis",
+      "answer_relevance_category",
+      "answer_relevance_judgment"
+    ],
+    "title": "AnswerRelevanceRawOutput",
+    "type": "object"
+  }
+# Additional turn of instructions to add to the chat
+instruction: "answer_relevance"
+# Data transformations to perform during post-processing
+transformations: ~
+parameters: ~
+sentence_boundaries: false

--- a/tests/granite_common/rag_agent_lib/testdata/input_yaml/answer_relevance_rewriter.yaml
+++ b/tests/granite_common/rag_agent_lib/testdata/input_yaml/answer_relevance_rewriter.yaml
@@ -1,0 +1,17 @@
+# Model name string, or null to use whatever is provided in the chat completion request
+model: ~
+# JSON schema of the model's output, or null if constrained decoding is not needed
+response_format: ~
+# Additional turn of instructions to add to the chat
+instruction: |
+  Rewrite the response for relevance.
+  The last assistant response is considered not fully relevant to the last user inquiry due to {answer_relevance_category}: {answer_relevance_analysis}
+  Decide if you agree with this assessment, then act according to the following instructions: 
+  If you disagree with the assessment, provide a verbatim copy of the original response.  DO NOT attempt to correct any other perceived defects in the response. 
+  If you agree with the assessment, provide an updated response that no longer fit the label {answer_relevance_category}, by {correction_method}.  Your response should be entirely based on the provided documents and should not rely on other prior knowledge. Your response should be suitable to be directly provided to the user.  It should NOT contain meta information regarding the original response, its assessment, or this instruction.  The user does not see any of these.  Your response is the only response they will see to their inquiry, in place of the original response.
+# Data transformations to perform during post-processing
+transformations: ~
+parameters:
+  # Rewritten response could be long.
+  max_completion_tokens: 1024
+sentence_boundaries: false

--- a/tests/granite_common/rag_agent_lib/testdata/input_yaml/hallucination.yaml
+++ b/tests/granite_common/rag_agent_lib/testdata/input_yaml/hallucination.yaml
@@ -38,7 +38,9 @@ response_format: |
 transformations:
   # Use logprobs to replace is_faithful flag with a probability
   - type: likelihood
-    positive_label: true
+    categories_to_values:
+      true: 1.0
+      false: 0.0
     input_path: ["*", "is_faithful"]
     output_name: "is_faithful_likelihood"
   # Replace "sentence_num" with sentence location and contents

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answer_relevance_classifier.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answer_relevance_classifier.json
@@ -1,0 +1,62 @@
+{
+  "messages": [
+    {
+      "content": "Who attended the meeting?",
+      "role": "user"
+    },
+    {
+      "content": "Many people attended the meeting.",
+      "role": "assistant"
+    },
+    {
+      "content": "answer_relevance",
+      "role": "user"
+    }
+  ],
+  "extra_body": {
+    "documents": [
+      {
+        "text": "Meeting attendees: Alice, Bob, Carol.",
+        "doc_id": "1"
+      },
+      {
+        "text": "Meeting time: 9:00 am to 11:00 am.",
+        "doc_id": "2"
+      }
+    ],
+    "guided_json": {
+      "properties": {
+        "answer_relevance_analysis": {
+          "title": "Answer Relevance Analysis",
+          "type": "string"
+        },
+        "answer_relevance_category": {
+          "title": "Answer Relevance Category",
+          "type": "string",
+          "enum": [
+            "Pertinent",
+            "Pertinent with relevant extra",
+            "Excessive unnecessary information",
+            "Unduly restrictive",
+            "Too vague or generic",
+            "Contextual misalignment",
+            "Misinterpreted inquiry",
+            "No attempt"
+          ]
+        },
+        "answer_relevance_judgment": {
+          "title": "Answer Relevance Judgment",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "answer_relevance_analysis",
+        "answer_relevance_category",
+        "answer_relevance_judgment"
+      ],
+      "title": "AnswerRelevanceRawOutput",
+      "type": "object"
+    }
+  },
+  "temperature": 0.0
+}

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answer_relevance_rewriter.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/answer_relevance_rewriter.json
@@ -1,0 +1,31 @@
+{
+  "messages": [
+    {
+      "content": "Who attended the meeting?",
+      "role": "user"
+    },
+    {
+      "content": "Many people attended the meeting.",
+      "role": "assistant"
+    },
+    {
+      "content": "Rewrite the response for relevance.\nThe last assistant response is considered not fully relevant to the last user inquiry due to Misinterpreted question: The response does not address the question about who attended the meeting. It provides a general statement about many people attending the meeting but does not specify who those people were. This is not relevant to the question asked. The response is also missing the closing tag.\nDecide if you agree with this assessment, then act according to the following instructions: \nIf you disagree with the assessment, provide a verbatim copy of the original response.  DO NOT attempt to correct any other perceived defects in the response. \nIf you agree with the assessment, provide an updated response that no longer fit the label Misinterpreted question, by providing answer only to the correct interpretation of the inquiry, or attempting clarification if the inquiry is ambiguous or otherwise confusing, or indicating that the desired answer is not available.  Your response should be entirely based on the provided documents and should not rely on other prior knowledge. Your response should be suitable to be directly provided to the user.  It should NOT contain meta information regarding the original response, its assessment, or this instruction.  The user does not see any of these.  Your response is the only response they will see to their inquiry, in place of the original response.\n",
+      "role": "user"
+    }
+  ],
+  "extra_body": {
+    "documents": [
+      {
+        "text": "Meeting attendees: Alice, Bob, Carol.",
+        "doc_id": "1"
+      },
+      {
+        "text": "Meeting time: 9:00 am to 11:00 am.",
+        "doc_id": "2"
+      }
+    ],
+    "guided_json": null
+  },
+  "temperature": 0.0,
+  "max_completion_tokens": 1024
+}

--- a/tests/granite_common/rag_agent_lib/testdata/test_canned_input/hallucination.json
+++ b/tests/granite_common/rag_agent_lib/testdata/test_canned_input/hallucination.json
@@ -9,7 +9,7 @@
       "role": "user"
     },
     {
-      "content": "Purple bumble fish are yellow. Green bumble fish are also yellow.",
+      "content": "<i0> Purple bumble fish are yellow. <i1> Green bumble fish are also yellow.",
       "role": "assistant"
     },
     {
@@ -20,7 +20,7 @@
   "extra_body": {
     "documents": [
       {
-        "text": "The only type of fish that is yellow is the purple bumble fish.",
+        "text": "<c0> The only type of fish that is yellow is the purple bumble fish.",
         "doc_id": "1"
       }
     ],


### PR DESCRIPTION
This PR adds code for the sentence splitting input transformation, as well as a stub for not-yet-implemented output transformations of sentence number to (begin, end, text).

I've also updated the tests with example model inputs for the answer relevance intrinsic.