### PR TITLE
Update API names and add gpt-oss support

### DIFF
--- a/notebooks/intrinsics_openai.ipynb
+++ b/notebooks/intrinsics_openai.ipynb
@@ -109,7 +109,7 @@
    "source": [
     "## Instantiate the input and output processing classes\n",
     "\n",
-    "The constructors for the classes `RagAgentLibRewriter` and `RagAgentLibResultProcessor`\n",
+    "The constructors for the classes `IntrinsicsRewriter` and `IntrinsicsResultProcessor`\n",
     "serve as factory methods to produce input and output processors, respectively, for \n",
     "a given intrinsic."
    ]
@@ -126,8 +126,8 @@
     "    f\"{io_yaml_file}\"\n",
     ")\n",
     "\n",
-    "rewriter = granite_common.RagAgentLibRewriter(config_file=io_yaml_file)\n",
-    "result_processor = granite_common.RagAgentLibResultProcessor(config_file=io_yaml_file)"
+    "rewriter = granite_common.IntrinsicsRewriter(config_file=io_yaml_file)\n",
+    "result_processor = granite_common.IntrinsicsResultProcessor(config_file=io_yaml_file)"
    ]
   },
   {
@@ -329,7 +329,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/intrinsics_transformers.ipynb
+++ b/notebooks/intrinsics_transformers.ipynb
@@ -51,11 +51,10 @@
    "outputs": [],
    "source": [
     "# Change the following two parameters as needed\n",
-    "intrinsic_name = \"query_rewrite\"\n",
+    "intrinsic_name = \"answerability\"\n",
     "base_model_name = \"granite-3.3-8b-instruct\"\n",
-    "# base_model_name = \"gpt-oss-20b\"\n",
     "\n",
-    "use_cuda = True\n",
+    "use_cuda = True  # Set to False to use default PyTorch device for this machine + model\n",
     "\n",
     "#######################################################################################\n",
     "# The code below adjusts the remaining constants according to the chosen intrinsic.\n",
@@ -73,6 +72,7 @@
     "    \"uncertainty\",\n",
     "]\n",
     "INTRINSICS_WITH_LOCAL_YAML_FILES = []\n",
+    "MODELS_WITHOUT_DOCUMENTS_INPUT = [\"gpt-oss-20b\"]\n",
     "\n",
     "io_yaml_file = None  # None -> load from Hugging Face Hub\n",
     "lora_dir = None  # None --> load from Hugging Face Hub\n",
@@ -121,7 +121,7 @@
    "source": [
     "## Instantiate the input and output processing classes\n",
     "\n",
-    "The constructors for the classes `RagAgentLibRewriter` and `RagAgentLibResultProcessor`\n",
+    "The constructors for the classes `IntrinsicsRewriter` and `IntrinsicsResultProcessor`\n",
     "serve as factory methods to produce input and output processors, respectively, for \n",
     "a given intrinsic."
    ]
@@ -138,8 +138,8 @@
     "    f\"{io_yaml_file}\"\n",
     ")\n",
     "\n",
-    "rewriter = granite_common.RagAgentLibRewriter(config_file=io_yaml_file)\n",
-    "result_processor = granite_common.RagAgentLibResultProcessor(config_file=io_yaml_file)"
+    "rewriter = granite_common.IntrinsicsRewriter(config_file=io_yaml_file)\n",
+    "result_processor = granite_common.IntrinsicsResultProcessor(config_file=io_yaml_file)"
    ]
   },
   {
@@ -170,6 +170,18 @@
     "# Apply appropriate values for those parameters.\n",
     "request_json[\"model\"] = intrinsic_name\n",
     "request_json[\"temperature\"] = 0.0\n",
+    "\n",
+    "# By convention, our canned JSON requests place RAG documents in extra_body/documents.\n",
+    "# Some models do not accept this parameter. If one of these models is the current base\n",
+    "# model, edit the request by putting the documents into the first turn of the messages.\n",
+    "if (\n",
+    "    \"extra_body\" in request_json\n",
+    "    and \"documents\" in request_json[\"extra_body\"]\n",
+    "    and base_model_name in MODELS_WITHOUT_DOCUMENTS_INPUT\n",
+    "):\n",
+    "    request_json = granite_common.intrinsics.util.move_documents_to_message(\n",
+    "        request_json\n",
+    "    )\n",
     "\n",
     "print(\"Original request:\")\n",
     "print(json.dumps(request_json, indent=2))"
@@ -212,7 +224,7 @@
    "source": [
     "## Running inference\n",
     "\n",
-    "Passing a request through the input processing `RagAgentLibRewriter.transform()` \n",
+    "Passing a request through the input processing `IntrinsicsRewriter.transform()` \n",
     "turns the request into something that can be sent directly to an OpenAI-compatible\n",
     "inference endpoint for the intrinsic.\n",
     "\n",
@@ -248,7 +260,7 @@
     "# format.\n",
     "tokenizer_input, generate_input, other_input = (\n",
     "    granite_common.util.chat_completion_request_to_transformers_inputs(\n",
-    "        rewritten_request, tokenizer\n",
+    "        rewritten_request, tokenizer, model\n",
     "    )\n",
     ")\n",
     "\n",
@@ -289,7 +301,7 @@
     "\n",
     "The raw output of some intrinsics requires some additional postprocessing to turn it \n",
     "into a form that is easy to consume in an application. This postprocessing occurs in\n",
-    "the method `RagAgentLibResultProcessor.transform()`. \n",
+    "the method `IntrinsicsResultProcessor.transform()`. \n",
     "\n",
     "The cells that follow show how to use this method to transform the raw output of the\n",
     "`chat.completions.create()` API call into the intrinsic's application-level output\n",
@@ -346,7 +358,7 @@
     "# from a chat completion request.\n",
     "tokenizer_input, generate_input, other_input = (\n",
     "    granite_common.util.chat_completion_request_to_transformers_inputs(\n",
-    "        rewritten_request, tokenizer\n",
+    "        rewritten_request, tokenizer, model\n",
     "    )\n",
     ")\n",
     "tokenizer_input"

--- a/src/granite_common/__init__.py
+++ b/src/granite_common/__init__.py
@@ -26,7 +26,7 @@ from .granite3.granite33 import (
     Granite33InputProcessor,
     Granite33OutputProcessor,
 )
-from .intrinsics import RagAgentLibResultProcessor, RagAgentLibRewriter
+from .intrinsics import IntrinsicsResultProcessor, IntrinsicsRewriter
 
 # The contents of __all__ must be strings
 __all__ = (
@@ -43,8 +43,8 @@ __all__ = (
         Granite33InputProcessor,
         Granite33OutputProcessor,
         GraniteChatCompletion,
-        RagAgentLibRewriter,
-        RagAgentLibResultProcessor,
+        IntrinsicsRewriter,
+        IntrinsicsResultProcessor,
         VLLMExtraBody,
     )
 )

--- a/src/granite_common/intrinsics/__init__.py
+++ b/src/granite_common/intrinsics/__init__.py
@@ -5,7 +5,7 @@ Support for the intrinsics in the RAG Agent Library.
 """
 
 # Local
-from .input import RagAgentLibRewriter
-from .output import RagAgentLibResultProcessor
+from .input import IntrinsicsRewriter
+from .output import IntrinsicsResultProcessor
 
-__all__ = ("RagAgentLibRewriter", "RagAgentLibResultProcessor")
+__all__ = ("IntrinsicsRewriter", "IntrinsicsResultProcessor")

--- a/src/granite_common/intrinsics/input.py
+++ b/src/granite_common/intrinsics/input.py
@@ -72,7 +72,7 @@ def mark_sentence_boundaries(
     return result
 
 
-class RagAgentLibRewriter(ChatCompletionRewriter):
+class IntrinsicsRewriter(ChatCompletionRewriter):
     """General-purpose chat completion rewriter for use with the models in the
     RAG Agent Library. Reads parameters of the model's input and output formats
     from a YAML configuration file and edits the input chat completion appropriately.

--- a/src/granite_common/intrinsics/output.py
+++ b/src/granite_common/intrinsics/output.py
@@ -903,7 +903,7 @@ NAME_TO_RULE = {cls.YAML_NAME: cls for cls in ALL_RULES}
 ############################################
 
 
-class RagAgentLibResultProcessor(ChatCompletionResultProcessor):
+class IntrinsicsResultProcessor(ChatCompletionResultProcessor):
     """General-purpose chat completion result processor for use with the models in the
     RAG Agent Library. Reads parameters of the model's input and output formats
     from a YAML configuration file and edits the input chat completion appropriately.


### PR DESCRIPTION
This PR updates some names for API calls that we missed in #45 and makes some other minor API changes that are necessary to support running the `gpt-oss` family of models with Transformers.