### PR TITLE
More fixes for flaky test case

### DIFF
--- a/tests/granite_common/intrinsics/rag/testdata/input_json/context_relevance.json
+++ b/tests/granite_common/intrinsics/rag/testdata/input_json/context_relevance.json
@@ -4,13 +4,5 @@
       "content": "Who is the CEO of Microsoft?",
       "role": "user"
     }
-  ],
-  "extra_body": {
-    "documents": [
-      {
-          "doc_id": "1",
-          "text": "Dummy document for testing."
-      }
-    ]
-  }
+  ]
 }

--- a/tests/granite_common/intrinsics/rag/testdata/test_canned_input/context_relevance.json
+++ b/tests/granite_common/intrinsics/rag/testdata/test_canned_input/context_relevance.json
@@ -10,12 +10,6 @@
     }
   ],
   "extra_body": {
-    "documents": [
-      {
-        "text": "Dummy document for testing.",
-        "doc_id": "1"
-      }
-    ],
     "guided_json": {
       "title": "ContextRelevanceOutput",
       "type": "object",

--- a/tests/granite_common/intrinsics/rag/testdata/test_run_transformers/context_relevance.json
+++ b/tests/granite_common/intrinsics/rag/testdata/test_run_transformers/context_relevance.json
@@ -3,7 +3,7 @@
         {
             "index": 0,
             "message": {
-                "content": "{\"context_relevance\": 0.005}",
+                "content": "{\"context_relevance\": 0.45192}",
                 "role": "assistant"
             }
         }


### PR DESCRIPTION
The test case for context relevance is still failing intermittently. This PR should hopefully put that issue to rest.