### PR TITLE
Remove deprecated pylint option

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -95,10 +95,6 @@ py-version=3.10
 # Discover python modules and packages in the file system subtree.
 recursive=no
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no


### PR DESCRIPTION
Our CI jobs keep throwing up warnings after the Pylint upgrade. Strangely, the pull request that put that upgrade in place didn't raise these warnings. This PR removes the offending configuration parameter.