### PR TITLE
Additional fix for issue #59 after merge of PR #68  and #71

### DIFF
--- a/src/granite_common/intrinsics/constants.py
+++ b/src/granite_common/intrinsics/constants.py
@@ -27,8 +27,8 @@ YAML_JSON_FIELDS = [
 ]
 """Fields of the YAML file that contain JSON values as strings"""
 
-INTRINSICS_HF_ORG = "generative-computing"
-"""Location of the RAG intrinsics libraries on Huggingface Hub"""
+RAG_INTRINSICS_LIB_REPO_NAME = "ibm-granite/rag-intrinsics-lib"
+"""Location of the RAG intrinsics library on Huggingface Hub"""
 
 BASE_MODEL_TO_CANONICAL_NAME = {
     "ibm-granite/granite-3.3-8b-instruct": "granite-3.3-8b-instruct",

--- a/src/granite_common/intrinsics/util.py
+++ b/src/granite_common/intrinsics/util.py
@@ -16,7 +16,7 @@ import yaml
 # Local
 from .constants import (
     BASE_MODEL_TO_CANONICAL_NAME,
-    INTRINSICS_HF_ORG,
+    RAG_INTRINSICS_LIB_REPO_NAME,
     YAML_JSON_FIELDS,
     YAML_OPTIONAL_FIELDS,
     YAML_REQUIRED_FIELDS,
@@ -78,42 +78,12 @@ def make_config_dict(
     return config_dict
 
 
-def get_lora_repo_id_mapping(hf_org: str) -> dict:
-    """
-    Loads the available LoRA models across the different orgs and create a
-    mapping from the LoRA model name to its repo ID.
-
-    Args:
-        hf_org (str): Organization with the LoRA models on Huggingface Hub.
-
-    Returns:
-        dict: Mapping from intrinsic model name to its repo ID.
-    """
-    # Third Party
-    from huggingface_hub import HfApi, HfFileSystem
-
-    api = HfApi()
-    models = api.list_models(author=hf_org)
-
-    fs = HfFileSystem()
-
-    intrinsics_name_mapping = {}
-    for model_info in models:
-        contents = fs.ls(model_info.id, detail=True)
-        mappings = {
-            item["name"].split("/")[-1]: item["name"].rsplit("/", 1)[0]
-            for item in contents
-            if item["type"] == "directory"
-        }
-        intrinsics_name_mapping |= mappings
-    return intrinsics_name_mapping
-
-
 def obtain_lora(
     intrinsic_name: str,
     target_model_name: str,
     /,
     alora: bool = False,
+    repo_id=RAG_INTRINSICS_LIB_REPO_NAME,
     cache_dir: str | None = None,
     file_glob: str = "*",
 ) -> pathlib.Path:
@@ -139,8 +109,6 @@ def obtain_lora(
     # Third Party
     import huggingface_hub
 
-    intrinsics_name_repo_id_mapping = get_lora_repo_id_mapping(INTRINSICS_HF_ORG)
-
     # Normalize target model name.
     # Confusing syntax here brought to you by pylint.
     target_model_name = BASE_MODEL_TO_CANONICAL_NAME.get(
@@ -152,7 +120,6 @@ def obtain_lora(
     lora_subdir_name = f"{intrinsic_name}/{lora_str}/{target_model_name}"
 
     # Download just the files for this LoRA if not already present
-    repo_id = intrinsics_name_repo_id_mapping[intrinsic_name]
     local_root_path = huggingface_hub.snapshot_download(
         repo_id=repo_id,
         allow_patterns=f"{lora_subdir_name}/{file_glob}",
@@ -178,6 +145,7 @@ def obtain_io_yaml(
     target_model_name: str,
     /,
     alora: bool = False,
+    repo_id=RAG_INTRINSICS_LIB_REPO_NAME,
     cache_dir: str | None = None,
 ) -> pathlib.Path:
     """
@@ -202,6 +170,7 @@ def obtain_io_yaml(
         intrinsic_name,
         target_model_name,
         alora,
+        repo_id=repo_id,
         cache_dir=cache_dir,
         file_glob="io.yaml",
     )

--- a/tests/granite_common/intrinsics/rag/test_rag_intrinsics_lib.py
+++ b/tests/granite_common/intrinsics/rag/test_rag_intrinsics_lib.py
@@ -21,7 +21,7 @@ import yaml
 from granite_common import ChatCompletion, IntrinsicsRewriter
 from granite_common.base.types import ChatCompletionResponse
 from granite_common.intrinsics import json_util, util
-from granite_common.intrinsics.constants import INTRINSICS_HF_ORG
+from granite_common.intrinsics.constants import RAG_INTRINSICS_LIB_REPO_NAME
 from granite_common.intrinsics.output import IntrinsicsResultProcessor
 import granite_common.util
 
@@ -289,10 +289,9 @@ def test_read_yaml():
     # Read from Hugging Face hub.
     # Requires "hf auth login" with read token while repo is private.
     path_suffix = "answerability/lora/granite-3.3-2b-instruct/io.yaml"
-    repo_id = f"{INTRINSICS_HF_ORG}/rag-intrinsics-lib"
     try:
         local_path = huggingface_hub.snapshot_download(
-            repo_id=repo_id,
+            repo_id=RAG_INTRINSICS_LIB_REPO_NAME,
             allow_patterns=path_suffix,
         )
     except requests.exceptions.HTTPError:


### PR DESCRIPTION
PR with fix for issue #59, undoing the following items from merge of PR #68 and #71 that's causing CI issues:
1. Revert back to using the public HF intrinsics lib: https://huggingface.co/ibm-granite/rag-intrinsics-lib
2. Remove auto discovery of intrinsics libs as the main `ibm-granite` org contains many different collections, which is slow. Revert back to original setup. May use a list of intrinsics libs in the constants for future iterations.

This PR depends on merge of HF PR: https://huggingface.co/ibm-granite/rag-intrinsics-lib/discussions/32