### PR TITLE
fix: Change to public rag-intrinsics-lib repo in GH Actions.

### DIFF
--- a/.github/actions/ollama-setup-intrinsics/action.yml
+++ b/.github/actions/ollama-setup-intrinsics/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Clone HF intrinsics repo
       shell: bash
       run: |
-        git clone https://huggingface.co/generative-computing/rag-intrinsics-lib
+        git clone https://huggingface.co/ibm-granite/rag-intrinsics-lib
 
     - name: List cloned files
       shell: bash


### PR DESCRIPTION
Missed this change for PR #86, revert change to private repo, only use public repo so tests will work.