### PR TITLE
fix: missing escape in regex for citation

### DIFF
--- a/src/granite_common/granite3/granite33/output.py
+++ b/src/granite_common/granite3/granite33/output.py
@@ -181,7 +181,7 @@ def _add_citation_response_spans(
     for sent_idx, sent in enumerate(response_sentences):
         # pylint: disable=anomalous-backslash-in-string
         pattern = (
-            f'{re.escape(CITE_START)}{{"document_id": "(\d+)"}}{re.escape(CITE_END)}'
+            f'{re.escape(CITE_START)}{{"document_id": "(\\d+)"}}{re.escape(CITE_END)}'
         )
         matches_iter = re.finditer(pattern, sent)
         for match in matches_iter:


### PR DESCRIPTION
Was previously seeing this warning:
```
/.../python3.12/site-packages/granite_common/granite3/granite33/output.py:184: SyntaxWarning: invalid escape sequence '\d'
  f'{re.escape(CITE_START)}{{"document_id": "(\d+)"}}{re.escape(CITE_END)}'
```

Looking at the other regexes, the escape sequence is there or the string is explicitly marked with `r`.