### PR TITLE
fix: remove refs/pr/3 revision from gpt-oss test configs

### DIFF
--- a/tests/granite_common/intrinsics/rag/test_rag_intrinsics_lib.py
+++ b/tests/granite_common/intrinsics/rag/test_rag_intrinsics_lib.py
@@ -234,7 +234,6 @@ _YAML_JSON_COMBOS_LIST = [
         inputs_file=_INPUT_JSON_DIR / "answerable.json",
         task="answerability",
         repo_id="ibm-granite/granite-lib-rag-gpt-oss-r1.0",
-        revision="refs/pr/3",
         base_model_id="openai/gpt-oss-20b",
     ),
     YamlJsonCombo(
@@ -242,7 +241,6 @@ _YAML_JSON_COMBOS_LIST = [
         inputs_file=_INPUT_JSON_DIR / "citations.json",
         task="citations",
         repo_id="ibm-granite/granite-lib-rag-gpt-oss-r1.0",
-        revision="refs/pr/3",
         base_model_id="openai/gpt-oss-20b",
     ),
     YamlJsonCombo(
@@ -250,7 +248,6 @@ _YAML_JSON_COMBOS_LIST = [
         inputs_file=_INPUT_JSON_DIR / "hallucination_detection.json",
         task="hallucination_detection",
         repo_id="ibm-granite/granite-lib-rag-gpt-oss-r1.0",
-        revision="refs/pr/3",
         base_model_id="openai/gpt-oss-20b",
     ),
     YamlJsonCombo(
@@ -258,7 +255,6 @@ _YAML_JSON_COMBOS_LIST = [
         inputs_file=_INPUT_JSON_DIR / "query_rewrite.json",
         task="query_rewrite",
         repo_id="ibm-granite/granite-lib-rag-gpt-oss-r1.0",
-        revision="refs/pr/3",
         base_model_id="openai/gpt-oss-20b",
     ),
 ]


### PR DESCRIPTION
## Summary
- Removed `revision="refs/pr/3"` from the 4 gpt-oss `YamlJsonCombo` test configurations
- The HF PR [ibm-granite/granite-lib-rag-gpt-oss-r1.0#3](https://huggingface.co/ibm-granite/granite-lib-rag-gpt-oss-r1.0/discussions/3) has been merged, so tests can now use the default `main` revision

## Test plan
- [x] Ran `test_canned_output` for all 4 gpt-oss cases locally — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)